### PR TITLE
added announcement command, nodemon for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -61,14 +61,19 @@ client.on('message', async (message) => {
     ev.addField('avatar', true)
   }
 
-  if (message.content === '!Announcement' && message.channel.id === '810255091751845888'){
+  if (message.content === '!Announcement' && message.channel.id === '953362393071775814'){
     await message.author.send('What is your announcement?')
 
     const filter = (m) => m.author.id === message.author.id
     const userAnnouncement = await message.author.dmChannel.awaitMessages(filter, {max: 1})
       .then((collected) => collected.first().content)
-    message.channel.send(`@everyone ${userAnnouncement}`)
-    message.delete()
+    if (userAnnouncement === 'cancel'){
+      await message.author.send('Canceled the announcement.')
+      message.delete()
+    }else{
+      await message.channel.send(`@everyone ${userAnnouncement}`)
+      message.delete()
+    }
   }
 
   ev.send()

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ client.on('message', async (message) => {
 
   const announcementChannel = '953362393071775814'
 
-  if (message.content.toLocaleLowerCase() === '!announcement' && message.channel.id === announcementChannel){
+  if (message.content.toLowerCase() === '!announcement' && message.channel.id === announcementChannel){
     await message.author.send('What is your announcement?')
 
     const filter = (m) => m.author.id === message.author.id

--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ client.on('message', async (message) => {
     ev.addField('avatar', true)
   }
 
-  if (message.content === '!Announcement' && message.channel.id === '953362393071775814'){
+  const announcementChannel = '953362393071775814'
+
+  if (message.content.toLocaleLowerCase() === '!announcement' && message.channel.id === announcementChannel){
     await message.author.send('What is your announcement?')
 
     const filter = (m) => m.author.id === message.author.id

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
   "dependencies": {
     "bufferutil": "^4.0.1",
     "discord.js": "^12.2.0",
@@ -10,6 +14,7 @@
     "erlpack": "discordapp/erlpack",
     "honeycomb-beeline": "^2.1.1",
     "libhoney": "^2.2.0",
+    "nodemon": "^2.0.15",
     "utf-8-validate": "^5.0.2"
   }
 }


### PR DESCRIPTION
Added a command for the Staff to use to make announcements in the Announcement channel. I didn't make the command roll specific since I made the command channel-specific and only Staff can type in the Announcement channel.

The staff member types `!Announcement` and the eggo bot will dm you asking `What is your announcement?` You then reply to the bot in the dm channel with what you want to announce.

<img width="301" alt="Screen Shot 2022-03-24 at 1 56 28 PM" src="https://user-images.githubusercontent.com/26470581/160008870-075d1f13-467d-4bc4-a7de-0f278c770c57.png">

The bot will delete the `!Announcement` command and then post your announcement while tagging `@everyone`. 

<img width="271" alt="Screen Shot 2022-03-24 at 1 57 49 PM" src="https://user-images.githubusercontent.com/26470581/160009063-7dc0424d-c252-44dc-99e7-5b925e195f9b.png">

I also added Nodemon to make testing much easier with the scripts for dev and starting the bot. 